### PR TITLE
update snapp links and dns lookup info

### DIFF
--- a/docs/Lokinet/Guides/AccessingSNApps.md
+++ b/docs/Lokinet/Guides/AccessingSNApps.md
@@ -14,17 +14,7 @@ To install lokinet, see the install guide [here](../../Lokinet/Guides/lokinet-li
 ## 2. Test services
 Jump onto a browser such as google chrome or firefox and try and go to one of the following SNApps:
 
-<!--
-- Block Explorer: [http://fyb983qpni4bp6nrm98skn33kr1robe979jb8wncxrewfy1rrtzo.loki/](http://fyb983qpni4bp6nrm98skn33kr1robe979jb8wncxrewfy1rrtzo.loki/)
-
-- Lokinet Wiki: [http://icxqqcpd3sfkjbqifn53h7rmusqa1fyxwqyfrrcgkd37xcikwa7y.loki/wiki](http://icxqqcpd3sfkjbqifn53h7rmusqa1fyxwqyfrrcgkd37xcikwa7y.loki/wiki)
-
-- [http://zqkddypocxnu3r53ddy6hkogcdi1xz6kcitjjsh483jom336wo5y.loki/](http://zqkddypocxnu3r53ddy6hkogcdi1xz6kcitjjsh483jom336wo5y.loki/)
-
-- Test for Photos: [http://rxudcygaj7gzqgigyrtti97g4wwaftqe9rd3s6pmu3wby7gxwcbo.loki/photos](http://rxudcygaj7gzqgigyrtti97g4wwaftqe9rd3s6pmu3wby7gxwcbo.loki/photos)
--->
-
-- Lokinet Wiki [http://wikicymsw5cy1h367oo9wwxuhp7igcrxcugy6kn4h5kgdzmq8qho.loki/wiki/](http://wikicymsw5cy1h367oo9wwxuhp7igcrxcugy6kn4h5kgdzmq8qho.loki/wiki/)
+- Lokinet Wiki [http://dw68y1xhptqbhcm5s8aaaip6dbopykagig5q5u1za4c7pzxto77y.loki/wiki/](http://dw68y1xhptqbhcm5s8aaaip6dbopykagig5q5u1za4c7pzxto77y.loki/wiki/)
 
 Congratulations, you now have access to the Lokinet.
 

--- a/docs/Lokinet/Guides/HostingSNApps.md
+++ b/docs/Lokinet/Guides/HostingSNApps.md
@@ -40,35 +40,18 @@ sudo systemctl restart lokinet
 
 ## 2. Finding your SNApps lokinet address.
 
-First we need to find the IP that our private tunnel adapter is connected to:
+You can find your current snapp address using a host lookup tool:
 
 ```
-nslookup localhost.loki
+nslookup -type=cname localhost.loki 127.0.0.1
 ```
 
-We should have an output similar to the below:
-```
-Server:		127.0.0.53
-Address:	127.0.0.53#53
-
-Non-authoritative answer:
-Name:	localhost.loki
-Address: 10.0.0.1
-```
-
-We want to use the IP Address that is shown under `Name: localhost.loki` in the next command:
+on linux you can use `dig`, the loki address to query is the same but the resolver uses the address `127.3.2.1` as to not conflict with other resolvers you may have installed.
 
 ```
-nslookup 10.0.0.1
+dig @127.3.2.1 -t cname localhost.loki
 ```
 
-Which will output our lokinet public key:
-
-```
-1.0.0.10.in-addr.arpa	name = jnzd4izeja5p7cf81bsy4t97szxpye5sewch88hontpwj6jdfqby.loki.
-```
-
-The public key is the url to your SNApp. Anyone running lokinet software will be able to access your hidden server using this public key.
 
 ## 3. Creating your SNApp
 Create a new directory within your home folder by running the following command in a terminal:

--- a/docs/Lokinet/Guides/LokinetIRC.md
+++ b/docs/Lokinet/Guides/LokinetIRC.md
@@ -28,7 +28,7 @@ Next to `Network name:` add the text `Lokinet Chat`.
 #### 2.1 Server details
 In this window, underneath the `Servers:` section click the `Add...` button.
 
-Copy and paste the following loki address into servers: `wikicymsw5cy1h367oo9wwxuhp7igcrxcugy6kn4h5kgdzmq8qho.loki`
+Copy and paste the following loki address into servers: `irc.dw68y1xhptqbhcm5s8aaaip6dbopykagig5q5u1za4c7pzxto77y.loki`
 
 Leave `Port:` as `6667` and `Password:` blank.
 


### PR DESCRIPTION
these are the links for 0.7.x and simplify the "get your snapp address" parts.